### PR TITLE
fix: Use active theme and stop assuming Doom One

### DIFF
--- a/nim-ts-mode.el
+++ b/nim-ts-mode.el
@@ -314,7 +314,7 @@ Mappings should be in the format (new-font-face 'old-font-face \"description\") 
   )
 
 
-(defvar nim-ts-mode--font-base-theme 'doom-one)
+(defvar nim-ts-mode--font-base-theme (car custom-enabled-themes))
 
 
 (defmacro nim-ts-mode--remap-fonts ()


### PR DESCRIPTION
It's currently assumed that the user is using the Doom One theme. This will check for the first theme listed in `custom-enabled-themes`, which is still not the best approach, but is at least a better solution than what is currently done.